### PR TITLE
Optimize map load times and filtering

### DIFF
--- a/frontend/src/components/EventInfoWindow.js
+++ b/frontend/src/components/EventInfoWindow.js
@@ -6,10 +6,21 @@ import '../App.css';
 class EventInfoWindow extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      visible: true
+    }
     this.infoWindowRef = React.createRef();
     this.contentElement = document.createElement(`div`);
   }
 
+  hide() {
+    this.setState({visible: false});
+  }
+
+  show() {
+    this.setState({visible: true});
+  }
+  
   componentDidUpdate(prevProps) {
     if (this.props.children !== prevProps.children) {
       ReactDOM.render(
@@ -23,7 +34,8 @@ class EventInfoWindow extends Component {
   render() {
     return (
       <InfoWindow
-        ref={this.infoWindowRef} {...this.props} />
+        ref={this.infoWindowRef} {...this.props}
+        visible={this.state.visible} />
     );
   }
 }

--- a/frontend/src/components/MapView.js
+++ b/frontend/src/components/MapView.js
@@ -32,7 +32,7 @@ class MapView extends Component {
     this.mapRef = React.createRef();
 
     this.reduxState = this.props.articles[0];
-
+    
     if (this.reduxState) {
       this.state = {
         allEvents: [],
@@ -62,8 +62,13 @@ class MapView extends Component {
     }
 
     var plusCode = this.state.plusCode;
-    this.queryEventsAndStoreInMemory(plusCode);
     this.renderInfo = this.renderInfo.bind(this);
+  }
+
+  async componentDidMount() {
+    await this.setState({ allEvents: [] });
+    await this.queryEventsAndStoreInMemory(this.state.plusCode);
+    await this.initializeRender();
   }
 
   // Called whenever the props change (when the university, filter, or time today are changed)
@@ -72,13 +77,7 @@ class MapView extends Component {
     if (nextProps.plusCode !== this.state.plusCode) {
       await this.setState({ allEvents: [], plusCode: nextProps.plusCode });
       await this.queryEventsAndStoreInMemory(nextProps.plusCode);
-      
-      // Render the map with events twice
-      // For some strange reason, whenever we dont call renderInfo a second time, the events wont show
-      await this.setState({ renderedEvents: [] });
-      this.renderInfo();
-      await this.setState({ renderedEvents: [] });
-      this.renderInfo();
+      await this.initializeRender();
     }
 
     // Shows all the events
@@ -95,6 +94,16 @@ class MapView extends Component {
       await this.setState({ isChecked: nextProps.articles[0].isChecked });
       this.handleTimeTodayChange();
     }
+  }
+
+  // Initializes the render for whenever the map get loaded first or whenever the plus code props change
+  async initializeRender() {  
+    // Render the map with events twice
+    // For some strange reason, whenever we dont call renderInfo a second time, the events wont show
+    await this.setState({ renderedEvents: [] });
+    this.renderInfo();
+    await this.setState({ renderedEvents: [] });
+    this.renderInfo();
   }
 
   // Shows all events

--- a/frontend/src/components/MapView.js
+++ b/frontend/src/components/MapView.js
@@ -45,7 +45,7 @@ class MapView extends Component {
         contents: null,
         resizeState: false,
         filter_choice: props.articles[0].filter_choice,
-	      isChecked: false
+	isChecked: false
       };
     } else {
       this.state = {
@@ -57,7 +57,7 @@ class MapView extends Component {
         contents: null,
         resizeState: false,
         filter_choice: props.articles[0].filter_choice,
-	      isChecked: false
+	isChecked: false
       };
     }
 


### PR DESCRIPTION
Changes the way we load the map. Originally, we would re-render for every single event and their previous events. This would make rendering be called up to 200+ times. This PR fixes that issue.

- The map will only be loaded "one" time when entering the map page. ("one" is more like two here. The map had to be loaded twice in order to show all the events. See the code for MapView.js for more details)

- Filtering was also optimized so that we dont re-render every single prop change from map view page. So when we filter with a new category, only those events will show but the other events will just hide. None of the events will be deleted in memory, they're just hidden. This change also applies to time. All the events will just be rendered once.